### PR TITLE
LLM source compatibility (fix)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,28 +6,21 @@ authors = ["Your Name <you@example.com>"]
 
 [tool.poetry.dependencies]
 # direct dependencies
-crewai = ">=0.79.4,<0.80.0"
-crewai-tools = ">=0.14.0,<0.25.0"
-langgraph = ">=0.2.69,<0.3.0"
-langchain = ">=0.3.15,<0.3.16"
-langchain-ibm = ">=0.3.5,<0.3.6"
-langchain-openai = ">=0.2.14,<0.3.0"
-langtrace-python-sdk = ">=3.5.1,<3.6.0"
-pydantic = "*"
-python-dotenv = "*"
+python = ">=3.10,<3.13"
+crewai = "0.95.0"
+crewai-tools = "0.32.0"
+litellm = "1.49.4"
+langchain = "0.3.15"
+langchain-ibm = "0.3.5"
+langgraph = "0.2.65"
+langtrace-python-sdk = "3.3.29"
 
 # indirect dependencies but specify versions here
 # to reduce install time that can be very long if not specified
-langchain-cohere = ">=0.3.4,<0.3.5"
-huggingface_hub = ">=0.16.4,<0.17.0"
-types-requests = ">=2.31.0.6,<2.31.0.10"
-selenium = ">=4.18.1,<4.19.0"
-instructor = ">=1.3.3,<1.4.0"
-ibm-cos-sdk = ">=2.13.6,<2.14.0"
-ibm-cos-sdk-core = ">=2.13.6,<2.14.0"
-ibm-cos-sdk-s3transfer = ">=2.13.6,<2.14.0"
-langsmith = ">=0.1.147,<0.2.0"
-urllib3 = ">=2.2.2,<2.3.0"
+langchain-cohere = "0.3.4"
+huggingface-hub = "0.27.1"
+langchain-core = "0.3.31"
+selenium = "4.28.0"
 
 [tool.poetry.scripts]
 ciso_run = "ciso_agent.main:run"

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,234 +1,254 @@
-aiohappyeyeballs==2.4.4
-aiohttp==3.11.11
-aiosignal==1.3.2
-alembic==1.14.1
-annotated-types==0.7.0
-anyio==4.8.0
-appdirs==1.4.4
-asgiref==3.8.1
-asttokens==3.0.0
-attrs==25.1.0
-auth0-python==4.7.2
-backoff==2.2.1
-bcrypt==4.2.1
-beautifulsoup4==4.13.3
-boto3==1.36.13
-botocore==1.36.13
-build==1.2.2.post1
-cachetools==5.5.1
-certifi==2025.1.31
-cffi==1.17.1
-charset-normalizer==3.4.1
-chroma-hnswlib==0.7.6
-chromadb==0.5.23
-click==8.1.8
-cohere==5.13.11
-colorama==0.4.6
-coloredlogs==15.0.1
-crewai==0.79.4
-crewai-tools==0.17.0
-cryptography==43.0.3
-dataclasses-json==0.6.7
-decorator==5.1.1
-Deprecated==1.2.18
-deprecation==2.1.0
-distro==1.9.0
-docker==7.1.0
-docstring_parser==0.16
-docx2txt==0.8
-durationpy==0.9
-embedchain==0.1.126
-executing==2.2.0
-fastapi==0.115.8
-fastavro==1.10.0
-filelock==3.17.0
-flatbuffers==25.1.24
-frozenlist==1.5.0
-fsspec==2025.2.0
-google-api-core==2.24.1
-google-auth==2.38.0
-google-cloud-aiplatform==1.79.0
-google-cloud-bigquery==3.29.0
-google-cloud-core==2.4.1
-google-cloud-resource-manager==1.14.0
-google-cloud-storage==2.19.0
-google-crc32c==1.6.0
-google-resumable-media==2.7.2
-googleapis-common-protos==1.66.0
-gptcache==0.1.44
-grpc-google-iam-v1==0.14.0
-grpcio==1.70.0
-grpcio-status==1.70.0
-grpcio-tools==1.70.0
-h11==0.14.0
-h2==4.2.0
-hpack==4.1.0
-httpcore==1.0.7
-httptools==0.6.4
-httpx==0.27.2
-httpx-sse==0.4.0
-huggingface-hub==0.16.4
-humanfriendly==10.0
-hyperframe==6.1.0
-ibm-cos-sdk==2.13.6
-ibm-cos-sdk-core==2.13.6
-ibm-cos-sdk-s3transfer==2.13.6
-ibm_watsonx_ai==1.2.6
-idna==3.10
-importlib_metadata==8.5.0
-importlib_resources==6.5.2
-iniconfig==2.0.0
-instructor==1.3.7
-ipython==8.32.0
-jedi==0.19.2
-Jinja2==3.1.5
-jiter==0.4.2
-jmespath==1.0.1
-json_repair==0.35.0
-jsonpatch==1.33
-jsonpickle==4.0.1
-jsonpointer==3.0.0
-jsonref==1.1.0
-jsonschema==4.23.0
-jsonschema-specifications==2024.10.1
-kubernetes==32.0.0
-lancedb==0.18.0
-langchain==0.3.15
-langchain-cohere==0.3.4
-langchain-community==0.3.15
-langchain-core==0.3.33
-langchain-experimental==0.3.4
-langchain-ibm==0.3.5
-langchain-openai==0.2.14
-langchain-text-splitters==0.3.5
-langgraph==0.2.69
-langgraph-checkpoint==2.0.10
-langgraph-sdk==0.1.51
-langsmith==0.1.147
-langtrace-python-sdk==3.5.1
-litellm==1.60.2
-lomond==0.3.3
-Mako==1.3.9
-markdown-it-py==3.0.0
-MarkupSafe==3.0.2
-marshmallow==3.26.1
-matplotlib-inline==0.1.7
-mdurl==0.1.2
-mem0ai==0.1.48
-mmh3==5.1.0
-monotonic==1.6
-mpmath==1.3.0
-msgpack==1.1.0
-multidict==6.1.0
-mypy-extensions==1.0.0
-networkx==3.4.2
-nodeenv==1.9.1
-numpy==1.26.4
-oauthlib==3.2.2
-onnxruntime==1.20.1
-openai==1.61.0
-opentelemetry-api==1.30.0
-opentelemetry-exporter-otlp-proto-common==1.30.0
-opentelemetry-exporter-otlp-proto-grpc==1.30.0
-opentelemetry-exporter-otlp-proto-http==1.30.0
-opentelemetry-instrumentation==0.51b0
-opentelemetry-instrumentation-asgi==0.51b0
-opentelemetry-instrumentation-fastapi==0.51b0
-opentelemetry-instrumentation-sqlalchemy==0.51b0
-opentelemetry-proto==1.30.0
-opentelemetry-sdk==1.30.0
-opentelemetry-semantic-conventions==0.51b0
-opentelemetry-util-http==0.51b0
-orjson==3.10.15
-outcome==1.3.0.post0
-overrides==7.7.0
-packaging==24.2
-pandas==2.1.4
-parso==0.8.4
-pexpect==4.9.0
-pluggy==1.5.0
-portalocker==2.10.1
-posthog==3.11.0
-prompt_toolkit==3.0.50
-propcache==0.2.1
-proto-plus==1.26.0
-protobuf==5.29.3
-ptyprocess==0.7.0
-pure_eval==0.2.3
-pyarrow==19.0.0
-pyasn1==0.6.1
-pyasn1_modules==0.4.1
-pycparser==2.22
-pydantic==2.10.6
-pydantic-settings==2.7.1
-pydantic_core==2.27.2
-Pygments==2.19.1
-PyJWT==2.10.1
-pylance==0.22.0
-pypdf==5.2.0
-PyPika==0.48.9
-pyproject_hooks==1.2.0
-pyright==1.1.393
-pysbd==0.3.4
-PySocks==1.7.1
-pytest==8.3.4
-python-dateutil==2.9.0.post0
-python-dotenv==1.0.1
-pytube==15.0.0
-pytz==2024.2
-pyvis==0.3.2
-PyYAML==6.0.2
-qdrant-client==1.13.2
-referencing==0.36.2
-regex==2024.11.6
-requests==2.32.2
-requests-oauthlib==2.0.0
-requests-toolbelt==1.0.0
-rich==13.9.4
-rpds-py==0.22.3
-rsa==4.9
-s3transfer==0.11.2
-safetensors==0.5.2
-schema==0.7.7
-selenium==4.18.1
-sentry-sdk==2.20.0
-shapely==2.0.7
-shellingham==1.5.4
-six==1.17.0
-sniffio==1.3.1
-sortedcontainers==2.4.0
-soupsieve==2.6
-SQLAlchemy==2.0.37
-stack-data==0.6.3
-starlette==0.45.3
-sympy==1.13.3
-tabulate==0.9.0
-tenacity==8.5.0
-tiktoken==0.7.0
-tokenizers==0.15.2
-tomli==2.2.1
-tomli_w==1.2.0
-tqdm==4.67.1
-trace-attributes==7.1.2
-traitlets==5.14.3
-transformers==4.38.0
-trio==0.28.0
-trio-websocket==0.11.1
-typer==0.15.1
-types-requests==2.31.0.9
-typing-inspect==0.9.0
-typing_extensions==4.12.2
-tzdata==2025.1
-ujson==5.10.0
-urllib3==2.2.3
-uv==0.5.28
-uvicorn==0.34.0
-uvloop==0.21.0
-watchfiles==1.0.4
-wcwidth==0.2.13
-websocket-client==1.8.0
-websockets==14.2
-wrapt==1.17.2
-wsproto==1.2.0
-yarl==1.18.3
-zipp==3.21.0
+aiohappyeyeballs==2.4.6 ; python_version >= "3.10" and python_version < "3.13"
+aiohttp==3.11.13 ; python_version >= "3.10" and python_version < "3.13"
+aiosignal==1.3.2 ; python_version >= "3.10" and python_version < "3.13"
+alembic==1.14.1 ; python_version >= "3.10" and python_version < "3.13"
+annotated-types==0.7.0 ; python_version >= "3.10" and python_version < "3.13"
+anyio==4.8.0 ; python_version >= "3.10" and python_version < "3.13"
+appdirs==1.4.4 ; python_version >= "3.10" and python_version < "3.13"
+asgiref==3.8.1 ; python_version >= "3.10" and python_version < "3.13"
+asttokens==3.0.0 ; python_version >= "3.10" and python_version < "3.13"
+async-timeout==4.0.3 ; python_version == "3.10"
+attrs==25.1.0 ; python_version >= "3.10" and python_version < "3.13"
+auth0-python==4.7.2 ; python_version >= "3.10" and python_version < "3.13"
+authlib==1.3.1 ; python_version >= "3.10" and python_version < "3.13"
+backoff==2.2.1 ; python_version >= "3.10" and python_version < "3.13"
+bcrypt==4.2.1 ; python_version >= "3.10" and python_version < "3.13"
+beautifulsoup4==4.13.3 ; python_version >= "3.10" and python_version < "3.13"
+blinker==1.9.0 ; python_version >= "3.10" and python_version < "3.13"
+boto3==1.37.0 ; python_version >= "3.10" and python_version < "3.13"
+botocore==1.37.0 ; python_version >= "3.10" and python_version < "3.13"
+build==1.2.2.post1 ; python_version >= "3.10" and python_version < "3.13"
+cachetools==5.5.2 ; python_version >= "3.10" and python_version < "3.13"
+certifi==2025.1.31 ; python_version >= "3.10" and python_version < "3.13"
+cffi==1.17.1 ; python_version >= "3.10" and python_version < "3.13" and (os_name == "nt" or platform_python_implementation != "PyPy") and (implementation_name != "pypy" or platform_python_implementation != "PyPy")
+charset-normalizer==3.4.1 ; python_version >= "3.10" and python_version < "3.13"
+chroma-hnswlib==0.7.6 ; python_version >= "3.10" and python_version < "3.13"
+chromadb==0.5.23 ; python_version >= "3.10" and python_version < "3.13"
+click==8.1.8 ; python_version >= "3.10" and python_version < "3.13"
+cohere==5.13.12 ; python_version >= "3.10" and python_version < "3.13"
+colorama==0.4.6 ; python_version >= "3.10" and python_version < "3.13"
+coloredlogs==15.0.1 ; python_version >= "3.10" and python_version < "3.13"
+crewai-tools==0.32.0 ; python_version >= "3.10" and python_version < "3.13"
+crewai==0.95.0 ; python_version >= "3.10" and python_version < "3.13"
+cryptography==43.0.3 ; python_version >= "3.10" and python_version < "3.13"
+dataclasses-json==0.6.7 ; python_version >= "3.10" and python_version < "3.13"
+decorator==5.2.1 ; python_version >= "3.10" and python_version < "3.13"
+deprecated==1.2.18 ; python_version >= "3.10" and python_version < "3.13"
+deprecation==2.1.0 ; python_version >= "3.10" and python_version < "3.13"
+distro==1.9.0 ; python_version >= "3.10" and python_version < "3.13"
+docker==7.1.0 ; python_version >= "3.10" and python_version < "3.13"
+docstring-parser==0.16 ; python_version >= "3.10" and python_version < "3.13"
+docx2txt==0.8 ; python_version >= "3.10" and python_version < "3.13"
+durationpy==0.9 ; python_version >= "3.10" and python_version < "3.13"
+embedchain==0.1.127 ; python_version >= "3.10" and python_version < "3.13"
+et-xmlfile==2.0.0 ; python_version >= "3.10" and python_version < "3.13"
+exceptiongroup==1.2.2 ; python_version == "3.10"
+executing==2.2.0 ; python_version >= "3.10" and python_version < "3.13"
+fastapi==0.115.8 ; python_version >= "3.10" and python_version < "3.13"
+fastavro==1.10.0 ; python_version >= "3.10" and python_version < "3.13"
+filelock==3.17.0 ; python_version >= "3.10" and python_version < "3.13"
+flatbuffers==25.2.10 ; python_version >= "3.10" and python_version < "3.13"
+frozenlist==1.5.0 ; python_version >= "3.10" and python_version < "3.13"
+fsspec==2025.2.0 ; python_version >= "3.10" and python_version < "3.13"
+google-api-core==2.24.1 ; python_version >= "3.10" and python_version < "3.13"
+google-auth==2.38.0 ; python_version >= "3.10" and python_version < "3.13"
+google-cloud-aiplatform==1.81.0 ; python_version >= "3.10" and python_version < "3.13"
+google-cloud-bigquery==3.29.0 ; python_version >= "3.10" and python_version < "3.13"
+google-cloud-core==2.4.2 ; python_version >= "3.10" and python_version < "3.13"
+google-cloud-resource-manager==1.14.1 ; python_version >= "3.10" and python_version < "3.13"
+google-cloud-storage==2.19.0 ; python_version >= "3.10" and python_version < "3.13"
+google-crc32c==1.6.0 ; python_version >= "3.10" and python_version < "3.13"
+google-resumable-media==2.7.2 ; python_version >= "3.10" and python_version < "3.13"
+googleapis-common-protos==1.68.0 ; python_version >= "3.10" and python_version < "3.13"
+gptcache==0.1.44 ; python_version >= "3.10" and python_version < "3.13"
+greenlet==3.1.1 ; python_version >= "3.10" and python_version < "3.13" and (platform_machine == "aarch64" or platform_machine == "ppc64le" or platform_machine == "x86_64" or platform_machine == "amd64" or platform_machine == "AMD64" or platform_machine == "win32" or platform_machine == "WIN32")
+grpc-google-iam-v1==0.14.0 ; python_version >= "3.10" and python_version < "3.13"
+grpcio-health-checking==1.70.0 ; python_version >= "3.10" and python_version < "3.13"
+grpcio-status==1.70.0 ; python_version >= "3.10" and python_version < "3.13"
+grpcio-tools==1.70.0 ; python_version >= "3.10" and python_version < "3.13"
+grpcio==1.70.0 ; python_version >= "3.10" and python_version < "3.13"
+h11==0.14.0 ; python_version >= "3.10" and python_version < "3.13"
+h2==4.2.0 ; python_version >= "3.10" and python_version < "3.13"
+hpack==4.1.0 ; python_version >= "3.10" and python_version < "3.13"
+httpcore==1.0.7 ; python_version >= "3.10" and python_version < "3.13"
+httptools==0.6.4 ; python_version >= "3.10" and python_version < "3.13"
+httpx-sse==0.4.0 ; python_version >= "3.10" and python_version < "3.13"
+httpx==0.27.2 ; python_version >= "3.10" and python_version < "3.13"
+huggingface-hub==0.27.1 ; python_version >= "3.10" and python_version < "3.13"
+humanfriendly==10.0 ; python_version >= "3.10" and python_version < "3.13"
+hyperframe==6.1.0 ; python_version >= "3.10" and python_version < "3.13"
+ibm-cos-sdk-core==2.13.5 ; python_version >= "3.10" and python_version < "3.13"
+ibm-cos-sdk-s3transfer==2.13.5 ; python_version >= "3.10" and python_version < "3.13"
+ibm-cos-sdk==2.13.5 ; python_version >= "3.10" and python_version < "3.13"
+ibm-watsonx-ai==1.2.8 ; python_version >= "3.10" and python_version < "3.13"
+idna==3.10 ; python_version >= "3.10" and python_version < "3.13"
+ijson==3.3.0 ; python_version >= "3.10" and python_version < "3.13"
+importlib-metadata==8.5.0 ; python_version >= "3.10" and python_version < "3.13"
+importlib-resources==6.5.2 ; python_version >= "3.10" and python_version < "3.13"
+instructor==1.7.2 ; python_version >= "3.10" and python_version < "3.13"
+ipython==8.32.0 ; python_version >= "3.10" and python_version < "3.13"
+jedi==0.19.2 ; python_version >= "3.10" and python_version < "3.13"
+jinja2==3.1.5 ; python_version >= "3.10" and python_version < "3.13"
+jiter==0.8.2 ; python_version >= "3.10" and python_version < "3.13"
+jmespath==1.0.1 ; python_version >= "3.10" and python_version < "3.13"
+json-repair==0.39.1 ; python_version >= "3.10" and python_version < "3.13"
+jsonpatch==1.33 ; python_version >= "3.10" and python_version < "3.13"
+jsonpickle==4.0.2 ; python_version >= "3.10" and python_version < "3.13"
+jsonpointer==3.0.0 ; python_version >= "3.10" and python_version < "3.13"
+jsonref==1.1.0 ; python_version >= "3.10" and python_version < "3.13"
+jsonschema-specifications==2024.10.1 ; python_version >= "3.10" and python_version < "3.13"
+jsonschema==4.23.0 ; python_version >= "3.10" and python_version < "3.13"
+kubernetes==32.0.1 ; python_version >= "3.10" and python_version < "3.13"
+lancedb==0.19.0 ; python_version >= "3.10" and python_version < "3.13"
+langchain-cohere==0.3.4 ; python_version >= "3.10" and python_version < "3.13"
+langchain-community==0.3.15 ; python_version >= "3.10" and python_version < "3.13"
+langchain-core==0.3.31 ; python_version >= "3.10" and python_version < "3.13"
+langchain-experimental==0.3.4 ; python_version >= "3.10" and python_version < "3.13"
+langchain-ibm==0.3.5 ; python_version >= "3.10" and python_version < "3.13"
+langchain-openai==0.2.14 ; python_version >= "3.10" and python_version < "3.13"
+langchain-text-splitters==0.3.5 ; python_version >= "3.10" and python_version < "3.13"
+langchain==0.3.15 ; python_version >= "3.10" and python_version < "3.13"
+langgraph-checkpoint==2.0.16 ; python_version >= "3.10" and python_version < "3.13"
+langgraph-sdk==0.1.53 ; python_version >= "3.10" and python_version < "3.13"
+langgraph==0.2.65 ; python_version >= "3.10" and python_version < "3.13"
+langsmith==0.1.147 ; python_version >= "3.10" and python_version < "3.13"
+langtrace-python-sdk==3.3.29 ; python_version >= "3.10" and python_version < "3.13"
+linkup-sdk==0.2.3 ; python_version >= "3.10" and python_version < "3.13"
+litellm==1.49.4 ; python_version >= "3.10" and python_version < "3.13"
+lomond==0.3.3 ; python_version >= "3.10" and python_version < "3.13"
+mako==1.3.9 ; python_version >= "3.10" and python_version < "3.13"
+markdown-it-py==3.0.0 ; python_version >= "3.10" and python_version < "3.13"
+markupsafe==3.0.2 ; python_version >= "3.10" and python_version < "3.13"
+marshmallow==3.26.1 ; python_version >= "3.10" and python_version < "3.13"
+matplotlib-inline==0.1.7 ; python_version >= "3.10" and python_version < "3.13"
+mdurl==0.1.2 ; python_version >= "3.10" and python_version < "3.13"
+mem0ai==0.1.55 ; python_version >= "3.10" and python_version < "3.13"
+mmh3==5.1.0 ; python_version >= "3.10" and python_version < "3.13"
+monotonic==1.6 ; python_version >= "3.10" and python_version < "3.13"
+mpmath==1.3.0 ; python_version >= "3.10" and python_version < "3.13"
+msgpack==1.1.0 ; python_version >= "3.10" and python_version < "3.13"
+multidict==6.1.0 ; python_version >= "3.10" and python_version < "3.13"
+mypy-extensions==1.0.0 ; python_version >= "3.10" and python_version < "3.13"
+networkx==3.4.2 ; python_version >= "3.10" and python_version < "3.13"
+nodeenv==1.9.1 ; python_version >= "3.10" and python_version < "3.13"
+numpy==1.26.4 ; python_version >= "3.10" and python_version < "3.13"
+oauthlib==3.2.2 ; python_version >= "3.10" and python_version < "3.13"
+onnxruntime==1.20.1 ; python_version >= "3.10" and python_version < "3.13"
+openai==1.64.0 ; python_version >= "3.10" and python_version < "3.13"
+openpyxl==3.1.5 ; python_version >= "3.10" and python_version < "3.13"
+opentelemetry-api==1.30.0 ; python_version >= "3.10" and python_version < "3.13"
+opentelemetry-exporter-otlp-proto-common==1.30.0 ; python_version >= "3.10" and python_version < "3.13"
+opentelemetry-exporter-otlp-proto-grpc==1.30.0 ; python_version >= "3.10" and python_version < "3.13"
+opentelemetry-exporter-otlp-proto-http==1.30.0 ; python_version >= "3.10" and python_version < "3.13"
+opentelemetry-instrumentation-asgi==0.51b0 ; python_version >= "3.10" and python_version < "3.13"
+opentelemetry-instrumentation-fastapi==0.51b0 ; python_version >= "3.10" and python_version < "3.13"
+opentelemetry-instrumentation-sqlalchemy==0.51b0 ; python_version >= "3.10" and python_version < "3.13"
+opentelemetry-instrumentation==0.51b0 ; python_version >= "3.10" and python_version < "3.13"
+opentelemetry-proto==1.30.0 ; python_version >= "3.10" and python_version < "3.13"
+opentelemetry-sdk==1.30.0 ; python_version >= "3.10" and python_version < "3.13"
+opentelemetry-semantic-conventions==0.51b0 ; python_version >= "3.10" and python_version < "3.13"
+opentelemetry-util-http==0.51b0 ; python_version >= "3.10" and python_version < "3.13"
+orjson==3.10.15 ; python_version >= "3.10" and python_version < "3.13"
+outcome==1.3.0.post0 ; python_version >= "3.10" and python_version < "3.13"
+overrides==7.7.0 ; python_version >= "3.10" and python_version < "3.13"
+packaging==24.2 ; python_version >= "3.10" and python_version < "3.13"
+pandas==2.1.4 ; python_version >= "3.10" and python_version < "3.13"
+parso==0.8.4 ; python_version >= "3.10" and python_version < "3.13"
+patronus==0.0.18 ; python_version >= "3.10" and python_version < "3.13"
+pdfminer-six==20231228 ; python_version >= "3.10" and python_version < "3.13"
+pdfplumber==0.11.5 ; python_version >= "3.10" and python_version < "3.13"
+pexpect==4.9.0 ; python_version >= "3.10" and python_version < "3.13" and sys_platform != "win32" and sys_platform != "emscripten"
+pillow==11.1.0 ; python_version >= "3.10" and python_version < "3.13"
+portalocker==2.10.1 ; python_version >= "3.10" and python_version < "3.13"
+posthog==3.15.1 ; python_version >= "3.10" and python_version < "3.13"
+prompt-toolkit==3.0.50 ; python_version >= "3.10" and python_version < "3.13"
+propcache==0.3.0 ; python_version >= "3.10" and python_version < "3.13"
+proto-plus==1.26.0 ; python_version >= "3.10" and python_version < "3.13"
+protobuf==5.29.3 ; python_version >= "3.10" and python_version < "3.13"
+ptyprocess==0.7.0 ; python_version >= "3.10" and python_version < "3.13" and sys_platform != "win32" and sys_platform != "emscripten"
+pure-eval==0.2.3 ; python_version >= "3.10" and python_version < "3.13"
+pyarrow==19.0.1 ; python_version >= "3.10" and python_version < "3.13"
+pyasn1-modules==0.4.1 ; python_version >= "3.10" and python_version < "3.13"
+pyasn1==0.6.1 ; python_version >= "3.10" and python_version < "3.13"
+pycparser==2.22 ; python_version >= "3.10" and python_version < "3.13" and (os_name == "nt" or platform_python_implementation != "PyPy") and (implementation_name != "pypy" or platform_python_implementation != "PyPy")
+pydantic-core==2.27.2 ; python_version >= "3.10" and python_version < "3.13"
+pydantic-settings==2.8.0 ; python_version >= "3.10" and python_version < "3.13"
+pydantic==2.10.6 ; python_version >= "3.10" and python_version < "3.13"
+pygments==2.19.1 ; python_version >= "3.10" and python_version < "3.13"
+pyjwt==2.10.1 ; python_version >= "3.10" and python_version < "3.13"
+pylance==0.23.0 ; python_version >= "3.10" and python_version < "3.13"
+pypdf==5.3.0 ; python_version >= "3.10" and python_version < "3.13"
+pypdfium2==4.30.1 ; python_version >= "3.10" and python_version < "3.13"
+pypika==0.48.9 ; python_version >= "3.10" and python_version < "3.13"
+pyproject-hooks==1.2.0 ; python_version >= "3.10" and python_version < "3.13"
+pyreadline3==3.5.4 ; python_version >= "3.10" and python_version < "3.13" and sys_platform == "win32"
+pyright==1.1.394 ; python_version >= "3.10" and python_version < "3.13"
+pysbd==0.3.4 ; python_version >= "3.10" and python_version < "3.13"
+pysocks==1.7.1 ; python_version >= "3.10" and python_version < "3.13"
+python-dateutil==2.9.0.post0 ; python_version >= "3.10" and python_version < "3.13"
+python-dotenv==1.0.1 ; python_version >= "3.10" and python_version < "3.13"
+pytube==15.0.0 ; python_version >= "3.10" and python_version < "3.13"
+pytz==2024.2 ; python_version >= "3.10" and python_version < "3.13"
+pyvis==0.3.2 ; python_version >= "3.10" and python_version < "3.13"
+pywin32==308 ; python_version >= "3.10" and python_version < "3.13" and (sys_platform == "win32" or platform_system == "Windows")
+pyyaml==6.0.2 ; python_version >= "3.10" and python_version < "3.13"
+qdrant-client==1.13.2 ; python_version >= "3.10" and python_version < "3.13"
+referencing==0.36.2 ; python_version >= "3.10" and python_version < "3.13"
+regex==2024.11.6 ; python_version >= "3.10" and python_version < "3.13"
+requests-oauthlib==2.0.0 ; python_version >= "3.10" and python_version < "3.13"
+requests-toolbelt==1.0.0 ; python_version >= "3.10" and python_version < "3.13"
+requests==2.32.3 ; python_version >= "3.10" and python_version < "3.13"
+rich==13.9.4 ; python_version >= "3.10" and python_version < "3.13"
+rpds-py==0.23.1 ; python_version >= "3.10" and python_version < "3.13"
+rsa==4.9 ; python_version >= "3.10" and python_version < "3.13"
+s3transfer==0.11.2 ; python_version >= "3.10" and python_version < "3.13"
+safetensors==0.5.2 ; python_version >= "3.10" and python_version < "3.13"
+schema==0.7.7 ; python_version >= "3.10" and python_version < "3.13"
+scrapegraph-py==1.12.0 ; python_version >= "3.10" and python_version < "3.13"
+selenium==4.28.0 ; python_version >= "3.10" and python_version < "3.13"
+sentry-sdk==2.22.0 ; python_version >= "3.10" and python_version < "3.13"
+serpapi==0.1.5 ; python_version >= "3.10" and python_version < "3.13"
+setuptools==75.8.0 ; python_version >= "3.10" and python_version < "3.13"
+shapely==2.0.7 ; python_version >= "3.10" and python_version < "3.13"
+shellingham==1.5.4 ; python_version >= "3.10" and python_version < "3.13"
+six==1.17.0 ; python_version >= "3.10" and python_version < "3.13"
+sniffio==1.3.1 ; python_version >= "3.10" and python_version < "3.13"
+sortedcontainers==2.4.0 ; python_version >= "3.10" and python_version < "3.13"
+soupsieve==2.6 ; python_version >= "3.10" and python_version < "3.13"
+spider-client==0.1.26 ; python_version >= "3.10" and python_version < "3.13"
+sqlalchemy==2.0.38 ; python_version >= "3.10" and python_version < "3.13"
+stack-data==0.6.3 ; python_version >= "3.10" and python_version < "3.13"
+starlette==0.45.3 ; python_version >= "3.10" and python_version < "3.13"
+sympy==1.13.3 ; python_version >= "3.10" and python_version < "3.13"
+tabulate==0.9.0 ; python_version >= "3.10" and python_version < "3.13"
+tenacity==9.0.0 ; python_version >= "3.10" and python_version < "3.13"
+tiktoken==0.7.0 ; python_version >= "3.10" and python_version < "3.13"
+tokenizers==0.20.3 ; python_version >= "3.10" and python_version < "3.13"
+tomli-w==1.2.0 ; python_version >= "3.10" and python_version < "3.13"
+tomli==2.2.1 ; python_version >= "3.10" and python_version < "3.13"
+tqdm==4.67.1 ; python_version >= "3.10" and python_version < "3.13"
+trace-attributes==7.1.0 ; python_version >= "3.10" and python_version < "3.13"
+traitlets==5.14.3 ; python_version >= "3.10" and python_version < "3.13"
+transformers==4.46.3 ; python_version >= "3.10" and python_version < "3.13"
+trio-websocket==0.12.1 ; python_version >= "3.10" and python_version < "3.13"
+trio==0.29.0 ; python_version >= "3.10" and python_version < "3.13"
+typer==0.15.1 ; python_version >= "3.10" and python_version < "3.13"
+types-requests==2.32.0.20241016 ; python_version >= "3.10" and python_version < "3.13"
+typing-extensions==4.12.2 ; python_version >= "3.10" and python_version < "3.13"
+typing-inspect==0.9.0 ; python_version >= "3.10" and python_version < "3.13"
+tzdata==2025.1 ; python_version >= "3.10" and python_version < "3.13"
+ujson==5.10.0 ; python_version >= "3.10" and python_version < "3.13"
+urllib3==2.1.0 ; python_version >= "3.10" and python_version < "3.13"
+uv==0.6.3 ; python_version >= "3.10" and python_version < "3.13"
+uvicorn==0.34.0 ; python_version >= "3.10" and python_version < "3.13"
+uvloop==0.21.0 ; python_version >= "3.10" and python_version < "3.13" and sys_platform != "win32" and sys_platform != "cygwin" and platform_python_implementation != "PyPy"
+validators==0.34.0 ; python_version >= "3.10" and python_version < "3.13"
+watchfiles==1.0.4 ; python_version >= "3.10" and python_version < "3.13"
+wcwidth==0.2.13 ; python_version >= "3.10" and python_version < "3.13"
+weaviate-client==4.11.0 ; python_version >= "3.10" and python_version < "3.13"
+websocket-client==1.8.0 ; python_version >= "3.10" and python_version < "3.13"
+websockets==15.0 ; python_version >= "3.10" and python_version < "3.13"
+wrapt==1.17.2 ; python_version >= "3.10" and python_version < "3.13"
+wsproto==1.2.0 ; python_version >= "3.10" and python_version < "3.13"
+yarl==1.18.3 ; python_version >= "3.10" and python_version < "3.13"
+zipp==3.21.0 ; python_version >= "3.10" and python_version < "3.13"

--- a/src/ciso_agent/llm.py
+++ b/src/ciso_agent/llm.py
@@ -24,7 +24,9 @@ api_domain_watsonx = "cloud.ibm.com"
 api_domain_azure = "azure.com"
 api_domain_azure_api = "azure-api.net"
 
-def init_agent_llm(model: str = "", api_url: str = "", api_key: str = ""):
+# Retreives and Returns Model, API URL and API key in that order from .env
+def get_llm_params(model: str = "", api_url: str = "", api_key: str = ""):
+    # get model
     model = model or os.getenv("LLM_MODEL_NAME") or os.getenv("OPENAI_MODEL_NAME")
     if not model:
         raise ValueError("Env variable `OPENAI_MODEL_NAME` is not set")
@@ -34,6 +36,11 @@ def init_agent_llm(model: str = "", api_url: str = "", api_key: str = ""):
 
     # get API key (if API is ollama, API key is not necessary)
     api_key = api_key or os.getenv("LLM_API_KEY") or os.getenv("OPENAI_API_KEY")
+
+    return model, api_url, api_key
+
+def init_agent_llm(model: str = "", api_url: str = "", api_key: str = ""):
+    model, api_url, api_key = get_llm_params()
 
     temperature = float(os.getenv("LLM_TEMPERATURE", "0.0"))
 
@@ -70,15 +77,7 @@ def init_agent_llm(model: str = "", api_url: str = "", api_key: str = ""):
 
 
 def init_llm(model: str = "", api_url: str = "", api_key: str = ""):
-    model = model or os.getenv("LLM_MODEL_NAME") or os.getenv("OPENAI_MODEL_NAME")
-    if not model:
-        raise ValueError("Env variable `OPENAI_MODEL_NAME` is not set")
-
-    # get API URL
-    api_url = api_url or os.getenv("LLM_BASE_URL") or os.getenv("MODEL_API_URL")
-
-    # get API key (if API is ollama, API key is not necessary)
-    api_key = api_key or os.getenv("LLM_API_KEY") or os.getenv("OPENAI_API_KEY")
+    model, api_url, api_key = get_llm_params()
 
     temperature = float(os.getenv("LLM_TEMPERATURE", "0.0"))
 

--- a/src/ciso_agent/manager.py
+++ b/src/ciso_agent/manager.py
@@ -25,7 +25,7 @@ from langgraph.graph import END, StateGraph
 from ciso_agent.agents.kubernetes_kubectl_opa import KubernetesKubectlOPACrew
 from ciso_agent.agents.kubernetes_kyverno import KubernetesKyvernoCrew
 from ciso_agent.agents.rhel_playbook_opa import RHELPlaybookOPACrew
-from ciso_agent.llm import call_llm, extract_code
+from ciso_agent.llm import get_llm_params, call_llm, extract_code
 
 load_dotenv()
 
@@ -136,9 +136,7 @@ class CISOManager:
     def task_selector(self, state: CISOState):
         goal = state["goal"]
 
-        manager_model = os.getenv("MANAGER_AGENT_MODEL_NAME", "gpt-4o-mini")
-        manager_api_key = os.getenv("MANAGER_AGENT_API_KEY")
-        manager_api_url = os.getenv("MANAGER_AGENT_API_URL")
+        manager_model, manager_api_url, manager_api_key = get_llm_params()
         summary_prompt = f"""Extract some required information from the following goal.
 Please return a parsable JSON string.
 If some info is not provided, set empty string to it.
@@ -280,10 +278,7 @@ Generated Policy:
 ```
 
 """
-
-        manager_model = os.getenv("MANAGER_AGENT_MODEL_NAME", "gpt-4o-mini")
-        manager_api_key = os.getenv("MANAGER_AGENT_API_KEY")
-        manager_api_url = os.getenv("MANAGER_AGENT_API_URL")
+        manager_model, manager_api_url, manager_api_key = get_llm_params()
 
         goal = state["goal"]
 

--- a/src/ciso_agent/tools/generate_kyverno.py
+++ b/src/ciso_agent/tools/generate_kyverno.py
@@ -108,7 +108,7 @@ spec:
           namespace: "!default"
 ```
 """
-        model, api_key, api_url = get_llm_params()
+        model, api_url, api_key = get_llm_params()
         print(f"Generating Kyverno policy code with '{model}'")
         print("Prompt:", prompt)
         answer = call_llm(prompt, model=model, api_key=api_key, api_url=api_url)

--- a/src/ciso_agent/tools/generate_kyverno.py
+++ b/src/ciso_agent/tools/generate_kyverno.py
@@ -16,7 +16,7 @@ import json
 import os
 from typing import Callable, Union
 
-from ciso_agent.llm import call_llm, extract_code
+from ciso_agent.llm import get_llm_params, call_llm, extract_code
 from ciso_agent.tools.utils import trim_quote
 from crewai.tools import BaseTool
 from pydantic import BaseModel, Field
@@ -108,11 +108,10 @@ spec:
           namespace: "!default"
 ```
 """
-        model = os.getenv("CODE_GEN_MODEL")
-        api_key = os.getenv("CODE_GEN_API_KEY")
+        model, api_key, api_url = get_llm_params()
         print(f"Generating Kyverno policy code with '{model}'")
         print("Prompt:", prompt)
-        answer = call_llm(prompt, model=model, api_key=api_key)
+        answer = call_llm(prompt, model=model, api_key=api_key, api_url=api_url)
         code = extract_code(answer, code_type="yaml")
         policy_file = policy_file.strip('"').strip("'").lstrip("{").rstrip("}")
         if not policy_file:

--- a/src/ciso_agent/tools/generate_opa_rego.py
+++ b/src/ciso_agent/tools/generate_opa_rego.py
@@ -120,7 +120,7 @@ for this example input data.
 }
 ```
 """
-        model, api_key, api_url = get_llm_params()
+        model, api_url, api_key = get_llm_params()
         print(f"Generating OPA Rego policy code with '{model}'")
         print("Prompt:", prompt)
         answer = call_llm(prompt, model=model, api_key=api_key, api_url=api_url)

--- a/src/ciso_agent/tools/generate_opa_rego.py
+++ b/src/ciso_agent/tools/generate_opa_rego.py
@@ -16,7 +16,7 @@ import json
 import os
 from typing import Callable, Union
 
-from ciso_agent.llm import call_llm, extract_code
+from ciso_agent.llm import get_llm_params, call_llm, extract_code
 from ciso_agent.tools.utils import trim_quote
 from crewai.tools import BaseTool
 from pydantic import BaseModel, Field
@@ -120,12 +120,10 @@ for this example input data.
 }
 ```
 """
-
-        model = os.getenv("CODE_GEN_MODEL")
-        api_key = os.getenv("CODE_GEN_API_KEY")
+        model, api_key, api_url = get_llm_params()
         print(f"Generating OPA Rego policy code with '{model}'")
         print("Prompt:", prompt)
-        answer = call_llm(prompt, model=model, api_key=api_key)
+        answer = call_llm(prompt, model=model, api_key=api_key, api_url=api_url)
         code = extract_code(answer, code_type="rego")
         policy_file = policy_file.strip('"').strip("'").lstrip("{").rstrip("}")
         if not policy_file:

--- a/src/ciso_agent/tools/generate_playbook.py
+++ b/src/ciso_agent/tools/generate_playbook.py
@@ -16,7 +16,7 @@ import json
 import os
 from typing import Callable, Union
 
-from ciso_agent.llm import call_llm, extract_code
+from ciso_agent.llm import get_llm_params, call_llm, extract_code
 from ciso_agent.tools.utils import trim_quote
 from crewai.tools import BaseTool
 from pydantic import BaseModel, Field
@@ -85,11 +85,10 @@ Points:
 - If you need command result as a collected data, you should add `ignore_errors: true` to the task.
 - Use Ansible module instead of command, if possible.
 """
-        model = os.getenv("CODE_GEN_MODEL")
-        api_key = os.getenv("CODE_GEN_API_KEY")
+        model, api_key, api_url = get_llm_params()
         print(f"Generating Playbook code with '{model}'")
         print("Prompt:", prompt)
-        answer = call_llm(prompt, model=model, api_key=api_key)
+        answer = call_llm(prompt, model=model, api_key=api_key, api_url=api_url)
         code = extract_code(answer, code_type="yaml")
         playbook_file = playbook_file.strip('"').strip("'").lstrip("{").rstrip("}")
         if not playbook_file:

--- a/src/ciso_agent/tools/generate_playbook.py
+++ b/src/ciso_agent/tools/generate_playbook.py
@@ -85,7 +85,7 @@ Points:
 - If you need command result as a collected data, you should add `ignore_errors: true` to the task.
 - Use Ansible module instead of command, if possible.
 """
-        model, api_key, api_url = get_llm_params()
+        model, api_url, api_key = get_llm_params()
         print(f"Generating Playbook code with '{model}'")
         print("Prompt:", prompt)
         answer = call_llm(prompt, model=model, api_key=api_key, api_url=api_url)


### PR DESCRIPTION
Added a helper function and calls to it to ensure ability to use LLMs from any source. Currently there are a couple inconsistencies with how environment variables are retrieved to set the variables used to call the LLM.

Tested with gpt-4o-mini from OpenAI and meta-llama/llama-3-3-70b-instruct from watsonx on scenario 3. gen-cis-b-rhel9-ansible-opa.